### PR TITLE
Update HtmlPurifierBehavior.php

### DIFF
--- a/Model/Behavior/HtmlPurifierBehavior.php
+++ b/Model/Behavior/HtmlPurifierBehavior.php
@@ -38,6 +38,25 @@ class HtmlPurifierBehavior extends ModelBehavior {
 	}
 
 /**
+ * beforeValidate
+ *
+ * @param Model $Model
+ * @param array $options
+ * @return boolean
+ */
+	public function beforeValidate(Model $Model, $options = array()) {
+		extract($this->settings[$Model->alias]); 
+
+		foreach($fields as $field) { 
+			if (isset($Model->data[$Model->alias][$field])) { 
+				$Model->data[$Model->alias][$field] = $this->purifyHtml($Model, $Model->data[$Model->alias][$field], $config);
+			}
+		}
+
+		return true;
+	}
+
+/**
  * Cleans markup
  *
  * @param Model $Model


### PR DESCRIPTION
beforeValidate was added to the behavior to validate the data after purifying is complete.

Originally , after validation was completed at the time of saving behavior saves the purified data which may even have no content in some cases.
