### PR TITLE
Don't extend form the wrapper class `Object`

### DIFF
--- a/Lib/Purifier.php
+++ b/Lib/Purifier.php
@@ -6,7 +6,7 @@
  * @copyright 2012 Florian Krämer
  * @license MIT
  */
-class Purifier extends Object {
+class Purifier extends CakeObject {
 /**
  * Purifier configurations
  *


### PR DESCRIPTION
Don't extend form the wrapper class `Object` as `object` is a reserved word in PHP >= 7.

This branch is based on tag `1.0.1` and should result in `1.0.2`