### PR TITLE
CakePHP 4.x fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ezyang/htmlpurifier": "*"
 	},
 	"require-dev": {
-                "cakephp/cakephp-codesniffer": "^3.0",
+        "cakephp/cakephp-codesniffer": "~4.2.0",
 		"phpunit/phpunit": "~8.5.0"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ezyang/htmlpurifier": "*"
 	},
 	"require-dev": {
-        "cakephp/cakephp-codesniffer": "~4.2.0",
+                "cakephp/cakephp-codesniffer": "~4.2.0",
 		"phpunit/phpunit": "~8.5.0"
 	},
 	"autoload": {

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -4,15 +4,20 @@
 
 Important: Before you start declaring a configuration you should lookup how HTML Purifier can be configured. http://htmlpurifier.org/docs
 
+In `src/Application.php` add:
+```php
+$this->addPlugin('Burzum/HtmlPurifier');
+```
+
 In `config/boostrap.php` you can either set the purifier config as an array or pass a native config object.
 
 The array style would look like this:
 
 ```php
-Purifier::config('ConfigName', array(
+Purifier::config('ConfigName', [
 		'HTML.AllowedElements' => 'a, em, blockquote, p, strong, pre, code, span,ul,ol,li,img',
 		'HTML.AllowedAttributes' => 'a.href, a.title, img.src, img.alt'
-	)
+	]
 );
 ```
 
@@ -48,6 +53,8 @@ or clean some dirty HTML directly by calling
 Purifier::clean($markup, 'ConfigName');
 ```
 
+*Remember to add `use Burzum\HtmlPurifier\Lib\Purifier;` when ussing `Purifier` class*
+
 For some automatization you can also use the Behavior or Helper.
 
 ## Caching ###
@@ -55,9 +62,9 @@ For some automatization you can also use the Behavior or Helper.
 It is recommended to change the path of the purifier libs cache to your `tmp` folder. For example:
 
 ```php
-Purifier::config('ConfigName', array(
+Purifier::config('ConfigName', [
 		'Cache.SerializerPath' => ROOT . DS . 'tmp' . DS . 'purifier',
-	)
+    ]
 );
 ```
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,7 @@
+# Installation
+
+## Installation with composer (CakePHP 4)
+
+```bash
+composer require burzum/cakephp-html-purifier:4.0.x-dev
+```

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -6,12 +6,12 @@ Set a config you want to use and the fields you want to sanitize.
 
 ```php
 public $actsAs = array(
-	'Burzum/HtmlPurifier.HtmlPurifier' => array(
-		'config' => 'ConfigName',
-		'fields' => array(
+	'Burzum/HtmlPurifier.HtmlPurifier' => [
+		'purifierConfig' => 'ConfigName',
+		'fields' => [
 			'body', 'excerpt'
-		)
-	)
+        ]
+    ]
 );
 ```
 

--- a/src/Shell/PurifierShell.php
+++ b/src/Shell/PurifierShell.php
@@ -8,9 +8,11 @@
  */
 namespace Burzum\HtmlPurifier\Shell;
 
+use Cake\Console\ConsoleOptionParser;
 use Cake\Console\Shell;
 use Cake\ORM\Locator\TableLocator;
 use Cake\ORM\Table;
+use Cake\Datasource\EntityInterface;
 
 /**
  * PurifierShell
@@ -31,7 +33,7 @@ class PurifierShell extends Shell
     /**
      * Gets the table from the shell args.
      *
-     * @return \Cake\ORM\Table;
+     * @return \Cake\ORM\Table
      */
     protected function _getTable()
     {
@@ -67,7 +69,7 @@ class PurifierShell extends Shell
     /**
      * Loads the purifier behavior for the given table if not already attached.
      *
-     * @param  \Cake\ORM\Table                 $table Table object.
+     * @param  \Cake\ORM\Table $table Table object.
      * @param  array Set of fields to sanitize
      * @return void
      */
@@ -100,7 +102,7 @@ class PurifierShell extends Shell
         }
         $total = $query->all()->count();
 
-        $this->info(__d('Burzum/HtmlPurifier', 'Sanitizing fields `{0}` in table `{1}`', implode(',', $fields), $table->table()));
+        $this->info(__d('Burzum/HtmlPurifier', 'Sanitizing fields `{0}` in table `{1}`', implode(',', $fields), $table->getTable()));
 
         $this->helper('progress')->output(
             [
@@ -142,7 +144,7 @@ class PurifierShell extends Shell
             ->select($fields)
             ->offset($chunkCount)
             ->limit($chunkSize)
-            ->orderDesc($table->aliasField($table->primarygetPrimaryKey()))
+            ->orderDesc($table->aliasField($table->getPrimaryKey()))
             ->all();
 
         if (empty($results)) {
@@ -151,6 +153,7 @@ class PurifierShell extends Shell
 
         foreach ($results as $result) {
             try {
+                $table->patchEntity($result, $result->toArray());
                 $table->save($result);
                 $chunkCount++;
             } catch (\Exception $e) {
@@ -162,7 +165,7 @@ class PurifierShell extends Shell
     /**
      * {@inheritDoc}
      */
-    public function getOptionParser()
+    public function getOptionParser(): ConsoleOptionParser
     {
         $parser = parent::getOptionParser();
 


### PR DESCRIPTION
Shell wasn't working because of deprecations.
After making it work again, I had to add a `patchEntity()`method because beforeMarshall Event wasn't firing (It is fired before request data is converted into entities)
Note that `Shells` are deprecated since 3.6 and will be removed on 5.x in favor of `Commands`

Edited a typo in the docs, added some lines and created Installation.md since there was a link to it but the file did not exist.

Updated `cakephp/cakephp-codesniffer` version dependency:
Closes #32